### PR TITLE
Update `TrueBrain/actions-flake8` to latest and pin `flake8` to current latest

### DIFF
--- a/.github/workflows/codespell-private.yml
+++ b/.github/workflows/codespell-private.yml
@@ -56,4 +56,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Flake8 with annotations
-        uses: TrueBrain/actions-flake8@v1.2
+        uses: TrueBrain/actions-flake8@v2.1
+        with:
+          flake8_version: 3.9.2


### PR DESCRIPTION
Update github action `Flake8 with annotations` to the latest version of that
Make `Flake8 with annotations` use a specific version of `flake8`, the current latest version 3.9.2